### PR TITLE
removed pygments style lock-in

### DIFF
--- a/better/static/better.css_t
+++ b/better/static/better.css_t
@@ -107,11 +107,6 @@ a.headerlink {
 
 /* code styles */
 
-pre, tt {
-    background-color: #eee;
-    color: #333;
-}
-
 pre {
     font-family: Monaco, Consolas, "Lucida Console", monospace;
     margin: 1rem -5px;

--- a/better/theme.conf
+++ b/better/theme.conf
@@ -1,7 +1,6 @@
 [theme]
 inherit = basic
 stylesheet = better.css
-pygments_style = sphinx
 
 [options]
 rightsidebar = false


### PR DESCRIPTION
This removes the lock-in of the pygment style to 'sphinx' and thus fixes #35.
Needed so dark variations of `better` can be created without having to fork|modify the theme.